### PR TITLE
Remove Transparent label on keymap and add XXX to NoKey/Disabled

### DIFF
--- a/packages/chrysalis-keymap/src/lib/db/blanks.js
+++ b/packages/chrysalis-keymap/src/lib/db/blanks.js
@@ -21,7 +21,7 @@ const BlankTable = {
             // NoKey
             code: 0,
             labels: {
-                primary: "",
+                primary: "XXX",
                 verbose: "Disabled"
             }
         },
@@ -29,7 +29,7 @@ const BlankTable = {
             // Transparent
             code: 65535,
             labels: {
-                primary: "[Trns]",
+                primary: "",
                 verbose: "Transparent"
             }
         }


### PR DESCRIPTION
Interim fix for https://github.com/keyboardio/Chrysalis/issues/225 until https://github.com/keyboardio/Chrysalis/issues/155 is finished.