### PR TITLE
focus: Support more reliable keyboard detection during enumeration

### DIFF
--- a/packages/chrysalis-focus/src/lib/chrysalis-focus.js
+++ b/packages/chrysalis-focus/src/lib/chrysalis-focus.js
@@ -104,12 +104,15 @@ class Focus {
         this.device = null
     }
 
-    async probe() {
-        return await this.request("help")
+    async isDeviceSupported(port) {
+        if (!port.device.isDeviceSupported) {
+            return true
+        }
+        return await port.device.isDeviceSupported(port)
     }
 
-    async getKeyboardType() {
-        return await this.request("hardware.layout")
+    async probe() {
+        return await this.request("help")
     }
 
     async _write_parts(parts, cb) {

--- a/packages/chrysalis-hardware-dygma-raise-ansi/package.json
+++ b/packages/chrysalis-hardware-dygma-raise-ansi/package.json
@@ -30,6 +30,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
+    "@chrysalis-api/focus": "^0.0.10",
     "react": "^16.5.2"
   },
   "devDependencies": {

--- a/packages/chrysalis-hardware-dygma-raise-ansi/src/lib/chrysalis-hardware-dygma-raise-ansi.js
+++ b/packages/chrysalis-hardware-dygma-raise-ansi/src/lib/chrysalis-hardware-dygma-raise-ansi.js
@@ -15,6 +15,7 @@
  */
 
 import KeymapANSI from "./components/Keymap-ANSI";
+import Focus from "@chrysalis-api/focus";
 
 const Raise_ANSI = {
   info: {
@@ -43,6 +44,17 @@ const Raise_ANSI = {
 
   flash: async () => {
     console.log("Not implemented yet.");
+  },
+
+  isDeviceSupported: async port => {
+    let focus = new Focus();
+    await focus.open(port.comName);
+    const layout = await focus.command("hardware.layout");
+    focus.close();
+    if (layout == "ansi") {
+      return true;
+    }
+    return false;
   }
 };
 

--- a/packages/chrysalis-hardware-dygma-raise-iso/package.json
+++ b/packages/chrysalis-hardware-dygma-raise-iso/package.json
@@ -30,6 +30,7 @@
     "prepublishOnly": "npm run build"
   },
   "dependencies": {
+    "@chrysalis-api/focus": "^0.0.10",
     "react": "^16.5.2"
   },
   "devDependencies": {

--- a/packages/chrysalis-hardware-dygma-raise-iso/src/lib/chrysalis-hardware-dygma-raise-iso.js
+++ b/packages/chrysalis-hardware-dygma-raise-iso/src/lib/chrysalis-hardware-dygma-raise-iso.js
@@ -15,6 +15,8 @@
  */
 
 import KeymapISO from "./components/Keymap-ISO";
+import Focus from "@chrysalis-api/focus";
+
 const Raise_ISO = {
   info: {
     vendor: "Dygma",
@@ -42,6 +44,17 @@ const Raise_ISO = {
 
   flash: async () => {
     console.log("Not implemented yet.");
+  },
+
+  isDeviceSupported: async port => {
+    let focus = new Focus();
+    await focus.open(port.comName);
+    const layout = await focus.command("hardware.layout");
+    focus.close();
+    if (layout == "iso") {
+      return true;
+    }
+    return false;
   }
 };
 


### PR DESCRIPTION
During enumeration, we can now call `focus.isDeviceSupported(port)`, which will dispatch to the hardware plugin, to see if this _variant_ of the board is supported or not. The implementation defaults to marking devices supported, unless the hardware plugin decides otherwise.

The ANSI and ISO variants of Dygma's Raise were adjusted to provide this new method, and allow only the appropriate variant through.
