### PR TITLE
 fixed: find exact device at isDeviceSupported (#378)

### DIFF
--- a/packages/chrysalis-focus/src/lib/chrysalis-focus.js
+++ b/packages/chrysalis-focus/src/lib/chrysalis-focus.js
@@ -158,7 +158,7 @@ class Focus {
                     await this._port.flush()
                     this.callbacks.push(resolve)
                     await this._write_parts(parts, () => {})
-                }, 500)
+                }, this.timeout)
             })
         } else {
             return new Promise(resolve => {

--- a/packages/chrysalis-hardware-dygma-raise-ansi/src/lib/chrysalis-hardware-dygma-raise-ansi.js
+++ b/packages/chrysalis-hardware-dygma-raise-ansi/src/lib/chrysalis-hardware-dygma-raise-ansi.js
@@ -51,10 +51,7 @@ const Raise_ANSI = {
     await focus.open(port.comName);
     const layout = await focus.command("hardware.layout");
     focus.close();
-    if (layout == "ansi") {
-      return true;
-    }
-    return false;
+    return layout.trim() === "ANSI" ? true : false;
   }
 };
 

--- a/packages/chrysalis-hardware-dygma-raise-iso/src/lib/chrysalis-hardware-dygma-raise-iso.js
+++ b/packages/chrysalis-hardware-dygma-raise-iso/src/lib/chrysalis-hardware-dygma-raise-iso.js
@@ -51,10 +51,7 @@ const Raise_ISO = {
     await focus.open(port.comName);
     const layout = await focus.command("hardware.layout");
     focus.close();
-    if (layout == "iso") {
-      return true;
-    }
-    return false;
+    return layout.trim() === "ISO" ? true : false;
   }
 };
 


### PR DESCRIPTION
- should use `trim()` to remove additional spaces (there were found)
- should compare with UpperCase keyboardName (that comes from `hardware.layout`)