### PR TITLE
#378: prevent opening port for ANSI and ISO in one time

### DIFF
--- a/packages/chrysalis-focus/src/lib/chrysalis-focus.js
+++ b/packages/chrysalis-focus/src/lib/chrysalis-focus.js
@@ -105,10 +105,20 @@ class Focus {
     }
 
     async isDeviceSupported(port) {
-        if (!port.device.isDeviceSupported) {
+        if (!port.device.info.keyboardType) {
             return true
         }
-        return await port.device.isDeviceSupported(port)
+    
+        let layout = localStorage.getItem(port.serialNumber)
+    
+        if (!layout) {
+            await this.open(port.comName, port.device)
+            layout = await this.command("hardware.layout")
+            this.close()
+            localStorage.setItem(port.serialNumber, layout)
+        }
+    
+        return layout.trim() === port.device.info.keyboardType
     }
 
     async probe() {

--- a/packages/chrysalis-focus/src/lib/chrysalis-focus.js
+++ b/packages/chrysalis-focus/src/lib/chrysalis-focus.js
@@ -105,20 +105,10 @@ class Focus {
     }
 
     async isDeviceSupported(port) {
-        if (!port.device.info.keyboardType) {
+        if (!port.device.isDeviceSupported) {
             return true
         }
-    
-        let layout = localStorage.getItem(port.serialNumber)
-    
-        if (!layout) {
-            await this.open(port.comName, port.device)
-            layout = await this.command("hardware.layout")
-            this.close()
-            localStorage.setItem(port.serialNumber, layout)
-        }
-    
-        return layout.trim() === port.device.info.keyboardType
+        return await port.device.isDeviceSupported(port)
     }
 
     async probe() {

--- a/packages/chrysalis-hardware-dygma-raise-ansi/src/lib/chrysalis-hardware-dygma-raise-ansi.js
+++ b/packages/chrysalis-hardware-dygma-raise-ansi/src/lib/chrysalis-hardware-dygma-raise-ansi.js
@@ -15,7 +15,6 @@
  */
 
 import KeymapANSI from "./components/Keymap-ANSI";
-import Focus from "@chrysalis-api/focus";
 
 const Raise_ANSI = {
   info: {
@@ -44,14 +43,6 @@ const Raise_ANSI = {
 
   flash: async () => {
     console.log("Not implemented yet.");
-  },
-
-  isDeviceSupported: async port => {
-    let focus = new Focus();
-    await focus.open(port.comName);
-    const layout = await focus.command("hardware.layout");
-    focus.close();
-    return layout.trim() === "ANSI" ? true : false;
   }
 };
 

--- a/packages/chrysalis-hardware-dygma-raise-ansi/src/lib/chrysalis-hardware-dygma-raise-ansi.js
+++ b/packages/chrysalis-hardware-dygma-raise-ansi/src/lib/chrysalis-hardware-dygma-raise-ansi.js
@@ -15,6 +15,7 @@
  */
 
 import KeymapANSI from "./components/Keymap-ANSI";
+import Focus from "@chrysalis-api/focus";
 
 const Raise_ANSI = {
   info: {
@@ -43,6 +44,18 @@ const Raise_ANSI = {
 
   flash: async () => {
     console.log("Not implemented yet.");
+  },
+
+  isDeviceSupported: async port => {
+    let focus = new Focus();
+    let layout = localStorage.getItem(port.serialNumber);
+    if (!layout) {
+      await focus.open(port.comName, port.device);
+      layout = await focus.command("hardware.layout");
+      focus.close();
+      localStorage.setItem(port.serialNumber, layout);
+    }
+    return layout.trim() === "ANSI";
   }
 };
 

--- a/packages/chrysalis-hardware-dygma-raise-iso/src/lib/chrysalis-hardware-dygma-raise-iso.js
+++ b/packages/chrysalis-hardware-dygma-raise-iso/src/lib/chrysalis-hardware-dygma-raise-iso.js
@@ -15,6 +15,7 @@
  */
 
 import KeymapISO from "./components/Keymap-ISO";
+import Focus from "@chrysalis-api/focus";
 
 const Raise_ISO = {
   info: {
@@ -43,6 +44,18 @@ const Raise_ISO = {
 
   flash: async () => {
     console.log("Not implemented yet.");
+  },
+
+  isDeviceSupported: async port => {
+    let focus = new Focus();
+    let layout = localStorage.getItem(port.serialNumber);
+    if (!layout) {
+      await focus.open(port.comName, port.device);
+      layout = await focus.command("hardware.layout");
+      focus.close();
+      localStorage.setItem(port.serialNumber, layout);
+    }
+    return layout.trim() === "ISO";
   }
 };
 

--- a/packages/chrysalis-hardware-dygma-raise-iso/src/lib/chrysalis-hardware-dygma-raise-iso.js
+++ b/packages/chrysalis-hardware-dygma-raise-iso/src/lib/chrysalis-hardware-dygma-raise-iso.js
@@ -15,7 +15,6 @@
  */
 
 import KeymapISO from "./components/Keymap-ISO";
-import Focus from "@chrysalis-api/focus";
 
 const Raise_ISO = {
   info: {
@@ -44,14 +43,6 @@ const Raise_ISO = {
 
   flash: async () => {
     console.log("Not implemented yet.");
-  },
-
-  isDeviceSupported: async port => {
-    let focus = new Focus();
-    await focus.open(port.comName);
-    const layout = await focus.command("hardware.layout");
-    focus.close();
-    return layout.trim() === "ISO" ? true : false;
   }
 };
 


### PR DESCRIPTION
As we are using `isDeviceSupported(port)` in ANSI and ISO keyboard types - there were been collapsed  - the port trying to oprening in one time for both and doesn't allow to open it for any of them.
This command should use once in chrysalis-focus.

Also will update `App.js` with small changes  in [Chrysalis](https://github.com/keyboardio/Chrysalis/issues/378) as clearing localStorage